### PR TITLE
✨ feat: 侧边菜单栏动态加载菜单项

### DIFF
--- a/src/components/Menu/MenuGroup.vue
+++ b/src/components/Menu/MenuGroup.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { provide, reactive, ref } from 'vue'
+import { useRouter } from 'vue-router'
+import type { MenuItem } from './MenuItem.vue'
+
+/* 组件参数
+  defaultActive: string - 默认激活的菜单项的 index
+  router: boolean - 是否开启路由菜单模式
+*/
+interface IProps {
+  defaultActive?: string
+  router?: boolean
+}
+
+const props = withDefaults(defineProps<IProps>(), {
+  defaultActive: '',
+  router: false
+})
+
+// eslint-disable-next-line vue/no-dupe-keys
+// 如果启用路由菜单模式，加载 router 实例，
+// 否则为 null，应该能提高性能吧:(
+const router = props.router ? useRouter() : null
+// 当前激活的菜单项 index
+const activeIndex = ref(props.defaultActive)
+// 处理菜单项点击事件
+const handleMenuItemClick = (item: MenuItem) => {
+  if (props.router && item.route && router) {
+    router.push(item.route).then((res) => {
+      if (!res) activeIndex.value = item.index
+    })
+  }
+  // 非路由模式啥也不做，提高组件灵活性
+  // 比如可以作按钮菜单，用户自己处理点击事件
+}
+
+/* MenuProvider 给MenuItem提供了一些数据和方法
+  activeIndex: string - 当前激活的菜单项 index
+  handleMenuItemClick: (item: MenuItem) => void - 处理菜单项点击事件
+*/
+export interface MenuProvider {
+  activeIndex: string
+  handleMenuItemClick: (item: MenuItem) => void
+}
+
+provide<MenuProvider>(
+  'rootMenu',
+  reactive({
+    activeIndex,
+    handleMenuItemClick
+  })
+)
+</script>
+
+<template>
+  <slot></slot>
+</template>

--- a/src/components/Menu/MenuItem.vue
+++ b/src/components/Menu/MenuItem.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { inject, computed } from 'vue'
+import { type RouteLocationRaw } from 'vue-router'
+import type { MenuProvider } from './MenuGroup.vue'
+import IconUser from '../icons/IconUser.vue'
+
+/* 组件参数
+  index: string - 菜单项的 index，跟ElementUI一样，建议设置成 router path (如果是用作路由菜单)
+  route: RouteLocationRaw - 跟router.push接受的参数一样，用于路由跳转
+  disabled: boolean - 是否禁用
+*/
+interface IProps {
+  index: string
+  route?: RouteLocationRaw
+  disabled?: boolean
+}
+
+const props = withDefaults(defineProps<IProps>(), {
+  disabled: false
+})
+
+export interface MenuItem {
+  index: string
+  route?: RouteLocationRaw
+}
+
+/* 组件事件
+  click: (item: MenuItem) => void - 点击菜单项时触发，用于触发用户自定义的 click 事件 (如果有)
+*/
+interface IEmits {
+  (e: 'click', item: MenuItem): void
+}
+
+const emits = defineEmits<IEmits>()
+
+// 注入根菜单组件
+const rootMenu = inject<MenuProvider>('rootMenu')
+// MenuItem不能单独使用，必须包裹在MenuGroup里面
+if (!rootMenu) {
+  throw new Error(
+    'Cannot inject rootMenu. Please make sure you have wrapped your menu items with <MenuGroup> component'
+  )
+}
+
+// 当前菜单项是否激活
+const isActive = computed(() => rootMenu?.activeIndex === props.index)
+
+// 默认点击事件处理函数
+const handleClick = () => {
+  if (props.disabled) return
+  if (rootMenu) rootMenu.handleMenuItemClick(props)
+  // 触发用户自定义的 click 事件 (如果有)
+  emits('click', {
+    index: props.index,
+    route: props.route
+  })
+}
+</script>
+
+<template>
+  <div
+    @click="handleClick"
+    :class="{
+      'is-active': isActive,
+      'is-disabled': props.disabled
+    }"
+    class="flex items-center w-full h-12 px-3 text-lg text-black transition-colors duration-300 cursor-pointer active:bg-indigo-200 hover:bg-indigo-100"
+  >
+    <slot>
+      <!-- 插槽，在这里放菜单项展示的内容 -->
+      <IconUser class="mr-3" />
+      <span>默认内容</span>
+    </slot>
+  </div>
+</template>
+
+<style scoped>
+/* TODO: 适配 dark mode */
+.is-active {
+  @apply bg-indigo-200 text-indigo-700 !important;
+}
+.is-disabled {
+  @apply opacity-40 cursor-not-allowed !important;
+}
+</style>

--- a/src/components/common/SideMenu.vue
+++ b/src/components/common/SideMenu.vue
@@ -1,14 +1,44 @@
-<script setup lang="ts"></script>
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import MenuGroup from '@/components/Menu/MenuGroup.vue'
+import MenuItem from '@/components/Menu/MenuItem.vue'
+import IconUser from '../icons/IconUser.vue'
+
+// 动态菜单
+// 从动态路由添加，如果有其他方法，之后再改
+// 比如说路由添加一个 meta 字段用来filter过滤，就不需要导入 userRoutesMap 和 useuserStore 了，已经改了
+// 添加一个 meta 字段用于指定图标
+const menuList = useRouter()
+  .getRoutes()
+  .filter((r) => r.meta?.toMenu)
+  .map((r) => ({
+    index: r.path,
+    title: r.meta.title
+  }))
+
+const iconMap = {
+  user: IconUser
+}
+</script>
 
 <template>
-  <div class="w-60 side-menu min-w-fit">
-    <div class="flex items-center justify-center h-10 text-white side-header bg-cyan-500">
+  <div id="side-menu" class="w-60 min-w-fit">
+    <div id="side-header" class="flex items-center justify-center h-10 text-white bg-cyan-500">
       🐬成绩管理系统
     </div>
-    <div class="menu-items">
-      <!-- TODO: 加载用户菜单 -->
+
+    <div id="menu-items">
+      <!-- 路由菜单 -->
+      <MenuGroup :default-active="$route.path" router>
+        <MenuItem v-for="(m, idx) in menuList" :key="idx" :index="m.index" :route="m.index">
+          <!-- 由于没有图标字段，先用这个图标代替 -->
+          <component :is="iconMap['user']" class="mr-2" />
+          {{ m.title }}
+        </MenuItem>
+      </MenuGroup>
     </div>
-    <div class="side-footer">
+
+    <div id="side-footer">
       <!-- TODO: 底部固定菜单-->
     </div>
   </div>

--- a/src/router/common.router.ts
+++ b/src/router/common.router.ts
@@ -16,7 +16,8 @@ export const commonRoutes: RouteRecordRaw[] = [
         name: 'home',
         component: HomeView,
         meta: {
-          title: '主页'
+          title: '主页',
+          toMenu: true
         }
       }
       // 动态路由添加至此

--- a/src/router/common.router.ts
+++ b/src/router/common.router.ts
@@ -2,8 +2,6 @@ import type { RouteRecordRaw } from 'vue-router'
 import AppLayout from '@/views/AppLayout.vue'
 import HomeView from '@/views/common/HomeView.vue'
 
-const APP_TITLE = import.meta.env.VITE_APP_TITLE
-
 export const commonRoutes: RouteRecordRaw[] = [
   {
     path: '/',
@@ -18,7 +16,7 @@ export const commonRoutes: RouteRecordRaw[] = [
         name: 'home',
         component: HomeView,
         meta: {
-          title: APP_TITLE + ' - 主页'
+          title: '主页'
         }
       }
       // 动态路由添加至此

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -44,6 +44,12 @@ router.beforeEach((to, from, next) => {
     return next({ name: 'auth' })
   }
 
+  // 已登录,访问登录页,跳转首页
+  if (to.name === 'auth' && user.isLogin) {
+    messageManager.showMessage({ message: '您已登录', type: 'error' })
+    return next({ name: 'home' })
+  }
+
   // 加载用户路由
   if (!isUserRoutesAdded) {
     if (user.isLogin && user.role) {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -4,6 +4,8 @@ import { userRoutesMap } from './user.router'
 import { useUserStore } from '@/stores'
 import { messageManager } from '@/components/alert'
 
+const APP_TITLE = import.meta.env.VITE_APP_TITLE
+
 // 动态路由
 let isUserRoutesAdded = false
 
@@ -36,7 +38,8 @@ router.beforeEach((to, from, next) => {
 
   // 设置页面标题
   if (to.meta.title) {
-    document.title = to.meta.title as string
+    const title = (to.meta.title ? to.meta.title + ' - ' : '') + APP_TITLE
+    document.title = title
   }
 
   // 鉴权

--- a/src/router/user.router.ts
+++ b/src/router/user.router.ts
@@ -6,13 +6,18 @@ const studentRoutes: RouteRecordRaw[] = [
     path: '/score',
     name: 'score',
     meta: {
-      title: '成绩查询'
+      title: '成绩查询',
+      toMenu: true
     },
     component: () => import('../views/student/ScoreDisplayView.vue')
   },
   {
     path: '/apply',
     name: 'apply',
+    meta: {
+      title: '申请查分',
+      toMenu: true
+    },
     component: () => import('../views/student/InquiryApplicationView.vue')
   }
 ]

--- a/src/router/user.router.ts
+++ b/src/router/user.router.ts
@@ -1,5 +1,4 @@
 import type { RouteRecordRaw } from 'vue-router'
-const APP_TITLE = import.meta.env.VITE_APP_TITLE
 
 // 学生路由
 const studentRoutes: RouteRecordRaw[] = [
@@ -7,7 +6,7 @@ const studentRoutes: RouteRecordRaw[] = [
     path: '/score',
     name: 'score',
     meta: {
-      title: `${APP_TITLE} - 我的成绩`
+      title: '成绩查询'
     },
     component: () => import('../views/student/ScoreDisplayView.vue')
   },


### PR DESCRIPTION
- 新增了菜单组、菜单项组件，使用方法跟ElementPlus的ElMenu差不多 [commit-7873294](https://github.com/ZbWeR/score-management-system/pull/7/commits/7873294476323ea5b0a6a1feb473c1f46488170b)
 - 菜单组、菜单项组件可用于创建路由菜单、按钮菜单 
- 路由标题元信息(meta.title)仅存储简短的标题，完整的标题统一在路由守卫中拼接 [commit-7003bad](https://github.com/ZbWeR/score-management-system/pull/7/commits/7003bada43e624d2618ac0ff168c383dd79d3b54)
- 路由元信息(meta)新增了toMenu字段，用于过滤路由，生成菜单 [commit-6ee29fb](https://github.com/ZbWeR/score-management-system/pull/7/commits/6ee29fbbf82ef2c94dde5ecac9bf36bd02c4922d)
- 实现了 侧边菜单栏动态加载菜单项 [commit-77b12b8](https://github.com/ZbWeR/score-management-system/pull/7/commits/77b12b843a9d14890929aa798552a2f51515ed68)
- 已登录用户访问登录页时跳转首页，这个是因为branch是基于这个commit创建的，懒得改了:(  [commit-78b2d9d](https://github.com/ZbWeR/score-management-system/pull/7/commits/78b2d9d0c0a3c3b2fe2982a8f10bf78281662e60)