### PR TITLE
✨ feat: 侧边栏动态加载，但是使用组件库

### DIFF
--- a/src/router/common.router.ts
+++ b/src/router/common.router.ts
@@ -11,15 +11,6 @@ export const commonRoutes: RouteRecordRaw[] = [
       requireAuth: true
     },
     children: [
-      {
-        path: '',
-        name: 'home',
-        component: HomeView,
-        meta: {
-          title: '主页',
-          toMenu: true
-        }
-      }
       // 动态路由添加至此
     ]
   },

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -95,10 +95,7 @@ export default router
  * 清除动态路由
  */
 export function resetRouter() {
-  console.log('清除之前')
-  console.log(router.getRoutes())
   removeDynamicRouteFns.forEach((fn) => {
     fn()
   })
-  console.log(router.getRoutes())
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -6,8 +6,8 @@ import { messageManager } from '@/components/alert'
 
 const APP_TITLE = import.meta.env.VITE_APP_TITLE
 
-// 动态路由
-let isUserRoutesAdded = false
+// 动态路由移除函数集合
+const removeDynamicRouteFns: (() => void)[] = []
 
 // 不匹配的路由跳转 404 页面
 const notMatchRoute: RouteRecordRaw = {
@@ -47,20 +47,15 @@ router.beforeEach((to, from, next) => {
     return next({ name: 'auth' })
   }
 
-  // 已登录,访问登录页,跳转首页
-  if (to.name === 'auth' && user.isLogin) {
-    messageManager.showMessage({ message: '您已登录', type: 'error' })
-    return next({ name: 'home' })
-  }
-
   // 加载用户路由
-  if (!isUserRoutesAdded) {
+  if (!user.isUserRoutesAdded) {
     if (user.isLogin && user.role) {
       router.removeRoute('not-match-redirect')
       userRoutesMap[user.role].forEach((route) => {
-        router.addRoute('appLayout', route)
+        const fn = router.addRoute('appLayout', route)
+        removeDynamicRouteFns.push(fn)
       })
-      isUserRoutesAdded = true
+      user.setRouteStatus(true)
       router.addRoute(notMatchRoute)
       return next({
         path: to.path,
@@ -95,3 +90,15 @@ router.beforeEach((to, from, next) => {
 })
 
 export default router
+
+/**
+ * 清除动态路由
+ */
+export function resetRouter() {
+  console.log('清除之前')
+  console.log(router.getRoutes())
+  removeDynamicRouteFns.forEach((fn) => {
+    fn()
+  })
+  console.log(router.getRoutes())
+}

--- a/src/router/user.router.ts
+++ b/src/router/user.router.ts
@@ -3,6 +3,12 @@ import type { RouteRecordRaw } from 'vue-router'
 // 学生路由
 const studentRoutes: RouteRecordRaw[] = [
   {
+    path: '',
+    name: 'home',
+    meta: { title: '我的成绩' },
+    component: () => import('../views/student/ScoreDisplayView.vue')
+  },
+  {
     path: '/score',
     name: 'score',
     meta: {
@@ -22,7 +28,32 @@ const studentRoutes: RouteRecordRaw[] = [
   }
 ]
 // 教师路由
-const teacherRoutes: RouteRecordRaw[] = []
+const teacherRoutes: RouteRecordRaw[] = [
+  {
+    path: '',
+    name: 'home',
+    meta: { title: '查分审批' },
+    component: () => import('../views/teacher/InquiryApprovalView.vue')
+  },
+  {
+    path: '/approval',
+    name: 'approval',
+    meta: { title: '查分审批', toMenu: true },
+    component: () => import('../views/teacher/InquiryApprovalView.vue')
+  },
+  {
+    path: '/manage',
+    name: 'manage',
+    meta: { title: '成绩管理', toMenu: true },
+    component: () => import('../views/teacher/ScoreManageView.vue')
+  },
+  {
+    path: '/import',
+    name: 'import',
+    meta: { title: '导入成绩', toMenu: true },
+    component: () => import('../views/teacher/ScoreImportView.vue')
+  }
+]
 
 export const userRoutesMap = {
   student: studentRoutes,

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -11,6 +11,8 @@ interface IUserStore {
   role: Roles | null
   userId: string | null
   username: string | null
+
+  isUserRoutesAdded: boolean // 是否已加载用户路由
 }
 
 export const useUserStore = defineStore({
@@ -20,7 +22,8 @@ export const useUserStore = defineStore({
     token: null,
     role: null,
     userId: null,
-    username: null
+    username: null,
+    isUserRoutesAdded: false
   }),
   actions: {
     // 设置用户信息
@@ -34,9 +37,15 @@ export const useUserStore = defineStore({
       this.isLogin = true
       this.token = token
     },
+    // 设置路由加载状态
+    setRouteStatus(status: boolean) {
+      this.isUserRoutesAdded = status
+    },
     logout() {
       this.$reset()
     }
   },
-  persist: true
+  persist: {
+    paths: ['isLogin', 'token', 'role', 'userId', 'username']
+  }
 })

--- a/src/views/AppLayout.vue
+++ b/src/views/AppLayout.vue
@@ -16,8 +16,13 @@ const toggleView = (target: string, index: number) => {
   router.push({ path: target })
 }
 
+// !临时代码,用于调试
 // 获取用户信息
 const state = useUserStore()
+const logout = () => {
+  state.logout() // 清除用户信息
+  router.push({ path: '/auth' }) // 跳转登录页面
+}
 </script>
 
 <template>
@@ -27,8 +32,9 @@ const state = useUserStore()
     <div class="drawer-content bg-zinc-50 flex flex-col items-center justify-center">
       <!-- TODO: 移动端按钮样式调整 -->
       <label for="my-drawer-2" class="btn btn-primary drawer-button lg:hidden">Open drawer</label>
-      <div class="bg-primary text-white p-4 rounded-md shadow-md mb-4">
+      <div class="bg-white p-4 rounded-md shadow-md mb-4">
         当前角色: {{ state.role }}
+        <button @click="logout" class="mt-4 btn block mx-auto">退出登录</button>
       </div>
       <router-view />
     </div>

--- a/src/views/AppLayout.vue
+++ b/src/views/AppLayout.vue
@@ -1,26 +1,75 @@
 <script setup lang="ts">
-import SideMenu from '@/components/common/SideMenu.vue'
+import { useRouter } from 'vue-router'
+import { ref } from 'vue'
+import router from '@/router'
+import { useUserStore } from '../stores/user'
+
+// 根据用户类型获取路由列表
+const routeList = useRouter()
+  .getRoutes()
+  .filter((r) => r.meta?.toMenu)
+const activeIndex = ref(0)
+
+// 切换路由
+const toggleView = (target: string, index: number) => {
+  activeIndex.value = index
+  router.push({ path: target })
+}
+
+// 获取用户信息
+const state = useUserStore()
 </script>
 
 <template>
-  <div id="app-layout" class="flex w-screen h-screen">
-    <!-- 
-      将侧边菜单栏的内容放在左右两侧
-     -->
-    <div class="flex-none side-menu-container">
-      <!-- 
-        侧边栏，使用 flex-none 固定宽度
-       -->
-      <SideMenu />
-    </div>
-    <div id="main-container" class="flex-row flex-1 bg-zinc-50">
-      <!-- 
-        二级 router-view，用于包含 APP 的业务内容
-        背景色为浅灰色，自动占满剩余空间
-        使用 flex-row 子元素垂直排列，与 HTML 默认语义一致
-        如有高级布局需求，可以在 view 中再嵌套一层 div
-      -->
+  <div class="drawer lg:drawer-open">
+    <input id="my-drawer-2" type="checkbox" class="drawer-toggle" />
+    <!-- 页面主体内容 -->
+    <div class="drawer-content bg-zinc-50 flex flex-col items-center justify-center">
+      <!-- TODO: 移动端按钮样式调整 -->
+      <label for="my-drawer-2" class="btn btn-primary drawer-button lg:hidden">Open drawer</label>
+      <div class="bg-primary text-white p-4 rounded-md shadow-md mb-4">
+        当前角色: {{ state.role }}
+      </div>
       <router-view />
+    </div>
+
+    <!-- 侧边栏 -->
+    <div class="drawer-side">
+      <label for="my-drawer-2" aria-label="close sidebar" class="drawer-overlay"></label>
+      <h1
+        class="tracking-wider font-bold text-white text-xl flex w-full justify-center p-4 bg-primary cursor-context-menu"
+      >
+        🐋成绩管理系统
+      </h1>
+      <ul class="flex-1 menu p-4 w-60 bg-base-200 text-base-content">
+        <li v-for="(route, index) in routeList" :key="route.path" class="mb-2">
+          <button
+            @click="toggleView(route.path, index)"
+            class="navbar-btn"
+            :class="
+              index === activeIndex
+                ? 'pointer-events-none hover:bg-p-2 hover:text-p-t bg-p-2 text-p-t'
+                : ''
+            "
+          >
+            {{ route.meta?.title }}
+          </button>
+        </li>
+      </ul>
+      <!-- TODO:底部功能按钮 -->
+      <ul class="w-full bg-base-200 menu hidden">
+        <li><button class="navbar-btn">切换主题</button></li>
+        <li><button class="navbar-btn">退出登录</button></li>
+      </ul>
     </div>
   </div>
 </template>
+
+<style scoped>
+.navbar-btn {
+  @apply text-center text-base block focus:bg-p-2 focus:text-p-t !important;
+}
+.drawer-side {
+  @apply flex flex-col !important;
+}
+</style>

--- a/src/views/common/LoginView.vue
+++ b/src/views/common/LoginView.vue
@@ -24,8 +24,11 @@ const RequestLogin = async () => {
     // 覆写 token 与用户信息
     userStore.setToken(res.token)
     userStore.setInfo(res.user_id, res.role)
+    userStore.setRouteStatus(false)
+    // 清除路由
+    resetRouter()
     messageManager.showMessage({ message: '登录成功!', type: 'success' })
-    router.push({ name: 'home', replace: true })
+    router.push({ name: 'appLayout', replace: true })
   } else {
     console.log('登录失败')
   }

--- a/src/views/common/LoginView.vue
+++ b/src/views/common/LoginView.vue
@@ -9,6 +9,7 @@ import { messageManager } from '@/components/alert'
 
 import IconUser from '@/components/icons/IconUser.vue'
 import IconPassword from '@/components/icons/IconPassword.vue'
+import { resetRouter } from '../../router/index'
 
 const userStore = useUserStore()
 

--- a/src/views/teacher/InquiryApprovalView.vue
+++ b/src/views/teacher/InquiryApprovalView.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div>查分审批</div>
+</template>

--- a/src/views/teacher/ScoreImportView.vue
+++ b/src/views/teacher/ScoreImportView.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div>成绩导入</div>
+</template>

--- a/src/views/teacher/ScoreManageView.vue
+++ b/src/views/teacher/ScoreManageView.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div>成绩管理</div>
+</template>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,7 +3,15 @@ import type { Config } from 'tailwindcss'
 export default {
   content: ['./src/**/*.{vue,ts}'],
   theme: {
-    extend: {}
+    extend: {
+      colors: {
+        primary: '#3e63dd',
+        'p-t': '#3358d4',
+        'p-0': '#fdfdfe',
+        'p-1': '#edf2fe',
+        'p-2': '#e1e9ff'
+      }
+    }
   },
   plugins: [require('daisyui')]
 } satisfies Config


### PR DESCRIPTION
- 使用 daisyUI 的侧边栏组件进行动态加载。因为这是个 UI 库，所以应该可以与已有 Menu 组件兼容，暂未做兼容处理
-  由于 daisyUI 样式透传相关限制，侧边栏与 appLayout 组件分离会失去样式效果，故直接在 appLayout 中统一开发了
- 解决#8，但是将时机调整到了登录后。现在，登陆后会清除以前的动态路由并添加新的动态路由